### PR TITLE
master: disable logging of environment

### DIFF
--- a/master/assets/config/master.cfg
+++ b/master/assets/config/master.cfg
@@ -284,12 +284,16 @@ for builder in meta_layers:
             repourl='git://github.com/oe-lite/{}.git'.format(layer),
             codebase=layer,
             mode='full', method='fresh',
-            workdir='build/meta/{}'.format(layer)))
+            workdir='build/meta/{}'.format(layer),
+            logEnviron=False,
+            ))
     factory.addStep(Git(
         repourl='git://github.com/oe-lite/urlgrabber.git',
         codebase='urlgrabber',
         mode='full', method='fresh',
-        workdir='build/lib/urlgrabber'))
+        workdir='build/lib/urlgrabber',
+        logEnviron=False,
+        ))
     factory.addStep(Trigger(
         schedulerNames=['machines'],
         waitForFinish=True))
@@ -313,42 +317,56 @@ factory.addStep(Git(
     repourl='git://github.com/oe-lite/core.git',
     codebase='core',
     mode='full', method='fresh',
-    workdir='build/meta/core'))
+    workdir='build/meta/core',
+    logEnviron=False,
+    ))
 factory.addStep(Git(
     doStepIf=has_codebase,
     repourl='git://github.com/oe-lite/base.git',
     codebase='base',
     mode='full', method='fresh',
-    workdir='build/meta/base'))
+    workdir='build/meta/base',
+    logEnviron=False,
+    ))
 factory.addStep(Git(
     doStepIf=has_codebase,
     repourl='git://github.com/oe-lite/fsl.git',
     codebase='fsl',
     mode='full', method='fresh',
-    workdir='build/meta/fsl'))
+    workdir='build/meta/fsl',
+    logEnviron=False,
+    ))
 factory.addStep(Git(
     doStepIf=has_codebase,
     repourl='git://github.com/oe-lite/python.git',
     codebase='python',
     mode='full', method='fresh',
-    workdir='build/meta/python'))
+    workdir='build/meta/python',
+    logEnviron=False,
+    ))
 factory.addStep(Git(
     doStepIf=has_codebase,
     repourl='git://github.com/oe-lite/qt.git',
     codebase='qt',
     mode='full', method='fresh',
-    workdir='build/meta/qt'))
+    workdir='build/meta/qt',
+    logEnviron=False,
+    ))
 factory.addStep(Git(
     doStepIf=has_codebase,
     repourl='git://github.com/oe-lite/xorg.git',
     codebase='xorg',
     mode='full', method='fresh',
-    workdir='build/meta/xorg'))
+    workdir='build/meta/xorg',
+    logEnviron=False,
+    ))
 factory.addStep(Git(
     repourl='git://github.com/oe-lite/urlgrabber.git',
     codebase='urlgrabber',
     mode='full', method='fresh',
-    workdir='build/lib/urlgrabber'))
+    workdir='build/lib/urlgrabber',
+    logEnviron=False,
+    ))
 # Write and log bakery.conf
 @renderer
 def bakery_conf_renderer(props):
@@ -364,7 +382,9 @@ def bakery_conf_renderer(props):
 factory.addStep(ShellCommand(
     name='cleanup',
     description='cleanup tmp/cache',
-    command=['rm', '-Rf', 'tmp/cache']))
+    command=['rm', '-Rf', 'tmp/cache']),
+    logEnviron=False,
+    )
 factory.addStep(StringDownload(
     name='write bakery.conf',
     slavedest = 'conf/bakery.conf',
@@ -377,7 +397,9 @@ factory.addStep(StringDownload(
 factory.addStep(ShellCommand(
     name='log bakery.conf',
     description='logging bakery.conf',
-    command=['cat', 'conf/bakery.conf']))
+    command=['cat', 'conf/bakery.conf'],
+    logEnviron=False,
+    ))
 
 # Write and log auto.conf
 factory.addStep(StringDownload(
@@ -397,7 +419,9 @@ factory.addStep(StringDownload(
 factory.addStep(ShellCommand(
     name='log auto.conf',
     description='logging auto.conf',
-    command=['cat', 'conf/auto.conf']))
+    command=['cat', 'conf/auto.conf'],
+    logEnviron=False,
+    ))
 
 # Bake!
 cmd = [
@@ -417,6 +441,7 @@ factory.addStep(
         flunkOnWarnings=Property('do_fail_warn'),
         warnOnWarnings=Property('do_fail_warn'),
         warnOnFailure=Property('do_fail_warn'),
+        logEnviron=False,
     )
 )
 


### PR DESCRIPTION
The slaves are configured through the environment when running the
docker container. Since the environment is logged to console by default,
it exposes the slave passwords to the world.

Avoid this by disabling the logging of the env. Note that later changes
to master.cfg need to be carefull to disable logEnviron when adding
steps.